### PR TITLE
Fix readdir access violation on x64

### DIFF
--- a/fontconfig/dirent.c
+++ b/fontconfig/dirent.c
@@ -21,7 +21,7 @@ extern "C"
 
 struct DIR
 {
-    long                handle; /* -1 for failed rewind */
+    intptr_t            handle; /* -1 for failed rewind */
     struct _finddata_t  info;
     struct dirent       result; /* d_name null iff first time */
     char                *name;  /* null-terminated char string */
@@ -42,7 +42,7 @@ DIR *opendir(const char *name)
         {
             strcat(strcpy(dir->name, name), all);
 
-            if((dir->handle = (long) _findfirst(dir->name, &dir->info)) != -1)
+            if((dir->handle = _findfirst(dir->name, &dir->info)) != -1)
             {
                 dir->result.d_name = 0;
             }
@@ -116,7 +116,7 @@ void rewinddir(DIR *dir)
     if(dir && dir->handle != -1)
     {
         _findclose(dir->handle);
-        dir->handle = (long) _findfirst(dir->name, &dir->info);
+        dir->handle = _findfirst(dir->name, &dir->info);
         dir->result.d_name = 0;
     }
     else


### PR DESCRIPTION
We use gtk-win32 in mono/libgdiplus. I've tried to get libgdiplus building and running on Windows to aid testing and debugging.

As part of this, I discovered that calling FcInit would cause an access violation here

```cpp
        if(!dir->result.d_name || _findnext(dir->handle, &dir->info) != -1)
        {
            result         = &dir->result;
            result->d_name = dir->info.name;
        }
```

This is because we passed an invalid handle to `_findnext`

The handle is invalid because we casted it from an `intptr_t` (returned from _findfirst) which has a size of 8, to a `long`, which has a size of 4. 

The fix is to change the native type of DIR.handle

Related: https://stackoverflow.com/questions/41844603/access-violation-continuously-thrown-by-findnext-c

Fixes https://github.com/mono/libgdiplus/issues/204 /cc @qmfrederik